### PR TITLE
Export to Gist

### DIFF
--- a/lib/app.css
+++ b/lib/app.css
@@ -26,7 +26,7 @@ html, body {
   height: 100%;
   width: 100%;
   grid-template-rows: 100%;
-  grid-template-columns: 40px auto 160px;
+  grid-template-columns: 40px auto 170px;
 }
 
 .gShareURI {
@@ -74,6 +74,15 @@ html, body {
   padding-right: 4px;
 }
 
+.toastHeader {
+  color: white;
+  width: auto;
+  height: 32px;
+  line-height: 22px;
+  padding-left: 4px;
+  padding-right: 4px;
+}
+
 .editorBody {
   width: 100%;
   height: calc(100% - 32px);
@@ -105,6 +114,14 @@ html, body {
   color: #32a9e6;
   font-size: 11px;
   font-family: Monaco, Menlo, "Ubuntu Mono", Consolas, source-code-pro, monospace;
+}
+
+.toastSpan {
+  padding-top: 4px;
+  font-size: 11px;
+  font-family: Monaco, Menlo, "Ubuntu Mono", Consolas, source-code-pro, monospace;
+  text-decoration: underline;
+  color: #fff;
 }
 
 .settingSection, .helpSection {
@@ -143,11 +160,6 @@ html, body {
   height: 32px;
 }
 
-.fa-cloud-upload:hover {
-    color: #87ec8d;
-    cursor: pointer;
-}
-
 a:hover {
   color: #87ec8d;
   cursor: pointer;
@@ -182,6 +194,36 @@ a:hover {
   border-radius: 1em;
 }
 
+.toast-container {
+  position: fixed;
+  margin: 0 auto;
+  left:0 ;
+  right: 0;
+  z-index: 99;
+  width: 350px;
+}
+
+.toast-container>div {
+  margin-bottom: 6px;
+  position: relative;
+}
+
+.toast {
+  position: relative;
+  margin-right: auto;
+  margin-left: auto;
+  width: 330px;
+  height: 22px;
+  z-index: 20;
+  opacity: 1;
+  background-color: rgba(20, 20, 20, 0.9);
+  padding-left: 10px;
+  vertical-align: middle;
+  color: white;
+  padding: 10px;
+  font-size: 11px;
+  border-radius: 1em;
+}
 
 .notSupported {
   top: 0;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "webpack --config config/webpack.config.js",
     "build-watch": "webpack --watch --config config/webpack.config.js",
-    "dev-server": "./node_modules/webpack-dev-server/bin/webpack-dev-server.js --config config/webpack.config.js"
+    "dev-server": "webpack-dev-server --config config/webpack.config.js"
   },
   "keywords": [],
   "author": "",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import * as ReactSplitPane from "react-split-pane";
 import { State } from "./State";
 import { EditorComponent } from "./components/Editor";
 import { CompilerOptionsComponent } from "./components/CompilerOptions";

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -598,10 +598,10 @@ export class AppComponent extends React.Component<any, {
             <canvas className="outputCanvas" ref={(self: any) => this.canvas = self} width={1200} height={1200} />
           </div>
           <div className="settingsOverlay" style={{ display: this.state.showSettings ? "" : "none" }}>
+            <div className="editorHeader">
             <span className="editorHeaderTitle">
               Settings
-              </span>
-            <div className="editorHeader">
+              </span>              
               <div className="editorHeaderButtons">
                 <a title="Toggle Settings" onClick={this.toggleSettings.bind(this)}>Hide <i className="fa fa-window-close fa-lg" aria-hidden="true"></i></a>
               </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import * as ReactSplitPane from "react-split-pane";
 import { State } from "./State";
 import { EditorComponent } from "./components/Editor";
 import { CompilerOptionsComponent } from "./components/CompilerOptions";
+import { ToastContainer } from "./components/Toast";
 import { lib } from "./lib"
 import { syscall } from "./syscall";
 import { IFrameSandbox } from "./iframesandbox";
@@ -111,6 +112,7 @@ const defaultHarnessText =
   `log(wasmInstance.exports.main());\n`;
 
 export class AppComponent extends React.Component<any, {
+  toasts: Array<Object>,
   compilerOptions: string,
   compilerVersion: number,
   isCompiling: boolean;
@@ -126,6 +128,7 @@ export class AppComponent extends React.Component<any, {
     this.installKeyboardShortcuts();
     State.app = this;
     this.state = {
+      toasts: [],
       compilerOptions: "-O3 -std=C99",
       compilerVersion: 1,
       isCompiling: false,
@@ -197,6 +200,20 @@ export class AppComponent extends React.Component<any, {
 
   }
 
+  exportFiddleToGist() {
+    var xhr = new XMLHttpRequest();
+    let self = this;
+    xhr.addEventListener("load", function () {
+      let gist_url = JSON.parse(this.response).html_url;
+      self.setState(prevState => ({
+        toasts: [...prevState.toasts, {"url" : gist_url }]
+      }));
+    });
+    xhr.open("POST", "https://api.github.com/gists", true);
+    xhr.setRequestHeader("Content-type", "application/json; charset=utf-8");
+    xhr.send(JSON.stringify(this.jsonForGist()));
+  }
+
   loadFiddledStateFromURI(fiddleURI: string) {
     State.fiddleURI = fiddleURI;
     var xhr = new XMLHttpRequest();
@@ -244,6 +261,26 @@ export class AppComponent extends React.Component<any, {
     }
   }
 
+  jsonForGist() {
+    let gistDescription: string = "source: http://wasmfiddle.com";
+    let fiddleURI: string = State.fiddleURI;
+    if (fiddleURI) {
+      gistDescription += "/?" + fiddleURI;
+    }
+    return {
+      description: gistDescription,
+      public: "true",
+      files: {
+        "main.c": {
+          content: this.mainEditor.editor.getValue()
+        },
+        "harness.js": {
+          content: this.harnessEditor.editor.getValue()
+        }
+      }
+    }
+  }
+
   saveFiddleState() {
     return {
       editors: {
@@ -254,6 +291,7 @@ export class AppComponent extends React.Component<any, {
       compilerVersion: this.state.compilerVersion
     }
   }
+
   loadFiddledState(fiddleState: any) {
     // For backwards compatibility.
     if (fiddleState.editors["main.c"]) {
@@ -533,6 +571,9 @@ export class AppComponent extends React.Component<any, {
     this.outputEditor.editor.insert(s + "\n");
     this.outputEditor.editor.gotoLine(Infinity);
   }
+  exportFiddle() {
+    this.exportFiddleToGist();
+  }
   share() {
     this.saveFiddleStateToURI();
     State.sendAppEvent("save", "Fiddle state to URI");
@@ -548,6 +589,11 @@ export class AppComponent extends React.Component<any, {
   }
   clear() {
     this.outputEditor.editor.setValue("");
+  }
+  dismissToast(index: number){
+    this.setState((prevState:any) => ({
+      toasts: prevState.toasts.filter((key:number, value:number) => value !== index )
+    }));
   }
   downloadLink: HTMLAnchorElement = null;
   onViewChanged(e: any) {
@@ -582,10 +628,12 @@ export class AppComponent extends React.Component<any, {
         }
       }
     }
+
     return <div className="gAppContainer">
       <a style={{ display: "none" }} ref={(self: any) => this.downloadLink = self} />
       <div className="gHeader">
         <div>
+          <ToastContainer toasts={this.state.toasts} dismiss={this.dismissToast.bind(this)}/>
           <div className="canvasOverlay" style={{ display: this.state.showCanvas ? "" : "none" }}>
             <div className="editorHeader">
               <span className="editorHeaderTitle">
@@ -601,7 +649,7 @@ export class AppComponent extends React.Component<any, {
             <div className="editorHeader">
             <span className="editorHeaderTitle">
               Settings
-              </span>              
+              </span>
               <div className="editorHeaderButtons">
                 <a title="Toggle Settings" onClick={this.toggleSettings.bind(this)}>Hide <i className="fa fa-window-close fa-lg" aria-hidden="true"></i></a>
               </div>
@@ -682,7 +730,8 @@ export class AppComponent extends React.Component<any, {
           <a className={this.wasmCode ? "" : "disabled-link"} title="Run: CTRL + Return" onClick={this.runHarness.bind(this)}><i className="fa fa-play-circle fa-lg" aria-hidden="true"></i></a>{' '}
           <a title="Toggle Settings" onClick={this.toggleSettings.bind(this)}><i className="fa fa-wrench fa-lg" aria-hidden="true"></i></a>{' '}
           <a title="Toggle Help" onClick={this.toggleHelp.bind(this)}><i className="fa fa-book fa-lg" aria-hidden="true"></i></a>{' '}
-          <i title="Share" onClick={this.share.bind(this)} className="fa fa-cloud-upload fa-lg" aria-hidden="true"></i>
+          <a title="Export to Gist" onClick={this.exportFiddle.bind(this)}><i className="fa fa-github fa-lg" aria-hidden="true"></i></a>{' '}
+          <a title="Share" onClick={this.share.bind(this)}><i className="fa fa-cloud-upload fa-lg" aria-hidden="true"></i></a>
         </div>
       </div>
       <div>

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,0 +1,38 @@
+import * as React from "react";
+
+export class ToastContainer extends React.Component<{
+    toasts: Array<Object>,
+    dismiss: Function
+}, any> {
+
+  constructor(props: any){
+    super(props);
+  }
+
+  public render() {
+    return (
+      <div className="toast-container">
+        {this.props.toasts.map((key: any, value: any) =>
+          <Toast onClick={this.props.dismiss.bind(this, value)} key={value} data={key}/>
+        )}
+      </div>
+    );
+  }
+}
+
+const Toast = (props: any) => {
+  return (
+  <div className="toast">
+    <div className="toastHeader">
+      <span className="editorHeaderTitle">
+        Gist created!
+        <a target="_blank" href={props.data.url}><span className="toastSpan">Open in new tab</span>
+        </a>
+      </span>
+      <div className="editorHeaderButtons">
+        <a title="Dismiss" onClick={props.onClick}>Dismiss <i className="fa fa-window-close fa-lg" aria-hidden="true"></i></a>
+      </div>
+    </div>
+  </div>
+);
+};


### PR DESCRIPTION
**Export to Gist**
1. Added button in `gHeader` for exporting code to Gist.
2. Coded calls for projecting C & JS code(doesn't include Wasm/Wast, Build, Output) on Gist's API to generate Gist Link. The request includes a customized description which adds the link to the fiddle( in case it is saved on WasmFiddle).
3. Generated stackable Toast(React Component) for showing the notification of Gist Generated with its Link.
4. A key binding has not been added.
5. This can be expanded more in future.

**Remaining 3 commits (Minor fixes, not important)**
1. Referred the binary directly in package.json for fixing an installation problem which is faced in Windows.
2. Settings modal's title was placed above the modal's header. Fixed it.
3. Removed unused import ReactSplitPane.
